### PR TITLE
More community documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/OPEV.mv
+++ b/.github/ISSUE_TEMPLATE/OPEV.mv
@@ -1,0 +1,131 @@
+---
+name: OpenVEX Enhancement Proposal (OPEV)
+about: Propose a change for the OpenVEX project
+labels: opev
+
+---
+<!-- 
+
+    Follow the template's instructions to open a new Enhancement
+    Proposal.
+-->
+
+# OPEV-00: My Awesome Feature
+
+<!--
+    Please choose a title that describes your enhancement.
+    After submitting the PR, the OPEV number will be the 
+    PR number assigned by GitHub.
+
+    Please edit the PR after submitting and set the correct
+    number and use the same title here in the body and in the
+    PR iteself.
+-->
+
+## 🖊️ Enhancement Overview
+
+<!--
+    Describe your enhancement to help the community understand
+    what you are proposing. Consider crafting your description for
+    an audience that may never have heard about the subject.
+
+    Make sure you list the benefits and consequences. 
+-->
+
+## 🧑‍💻 Enhancement Proposal Authors
+
+<!--
+    List the GitHub handles of the community members proposing
+    the OPEV. From one to as many as are involved in the enhancement design.
+-->
+- @author1
+- @author2
+
+## 👩‍🔧 Sponsoring Maintainers
+
+<!--
+    Any OpenVEX enhancements proposed by non maintainers need to have 
+    at least one active OpenVEX maintainer as sponsor to merge
+    (refer to GOVERNANCE.md). List their GitHub handles here:
+    GitHub. If in doubt, check the MAINTAINERS file.
+-->
+- @maintainer1
+- @maintainer2
+
+## 📋 OpenVEX Projects
+
+<!--
+    Please list the projects related to this enhancement. Enumerating them
+    here helps to draw the attention of all interested community members.
+-->
+
+- openvex/repo1
+- openvex/repo2
+
+## 📐 Specs and Documents
+
+<!--
+    Are there any design documents, specifications or related documents
+    related to this OPEV? Please link them here. Leave 'NONE' if not
+-->
+NONE
+
+## ❓ Enhancement Questions
+
+Does this enhancement propose a change to the OpenVEX project's governance
+structure?
+<!--
+    Enhancements changing the project's governance have stricter
+    approval requirements. Refer to GOVERNANCE.MD
+-->
+**YES** | **NO**
+
+
+Does this enhancement propose a breaking change with the upstream VEX design
+established by the VEX Working Group?
+<!--
+    Enhancements should be compatible with the overall VEX work done by
+    the VEX Working Group. Any breaking changes should be presented at 
+    the general VEX meetings before approval.
+-->
+**YES** | **NO**
+
+
+## 💬 Discussion Start Date:
+
+OPEVs shall be discussed for no longer than 30 days after which the vote tally
+will be computed and the proposal will either merge or be rejected. 
+
+**Start Date: 202Y-MM-DD**
+
+## 🗳️ Voting Results
+
+Final Enhancement Vote Tally:
+
+👍 : X Votes
+
+👎 : X Votes
+
+**Result:** __`APPROVED`__ | __`REJECTED`__
+
+----
+<!--
+** ✂️✂️✂️ Cut here ✂️✂️✂️ **
+
+If this OPEV is approved, please copy the markdown from the title up to here
+and open a pull request referencing this issue and commiting the markdown
+in a file named as follows:
+
+   /enhancements/opev-001.md
+
+(substitute 001 with the actual number of you issue, padded with zeroes)
+-->
+
+
+## ℹ️ Voting Instructions: 
+
+To vote for this enhancement, maintainers should add a comment with a 👍 emoji
+to show support or 👎 to reject the enhancement.  After voting is over (usually 
+after 30 days), votes will be computed by the project's mantainers and
+registered in this issue. Refer to  [GOVERNANCE.md](GOVERNANCE.md) for details
+on how many votes are required to approve and when voting ends.

--- a/.github/ISSUE_TEMPLATE/maintainer-nomination.md
+++ b/.github/ISSUE_TEMPLATE/maintainer-nomination.md
@@ -1,0 +1,83 @@
+---
+name: Maintainer Nomination
+about: Nominate a community member to be promoted to maintainer!
+labels: nomination
+
+---
+<!-- 
+    Follow this template's instructions to nominate a community
+    member who deserves a promotion to maintainer status. 
+-->
+
+# Maintainer Nomination: Volfi J Inkinson
+<!--
+ Please list the name ot handle of the maintainer in the title and
+ use the same title when you open the issue
+-->
+
+GitHub handle: @nominee
+
+## Project Contributions
+
+The OpenVEX project recognizes individual contributors who have gone over
+and beyond to help our mission. We are always happy to welcome new enthusastic
+comunity members to the OpenVEX maintainers team.
+
+### Issues and PRs
+
+<!--
+    Please list some PRs or issues where the nominee has shown 
+    constant dedication and commitment to the project over the 
+    past six months
+-->
+
+- Issue/PR 1
+- Issue/PR 2
+- Issue/PR 3
+- Issue/PR 4
+
+### Non Code or other Contributions
+
+<!--
+    We recognize that contributing to open source can take many shapes and
+    we value non-code contributions just as much! If this is the case of 
+    the nominee, pleas type a few words explaining their merits.
+-->
+
+## Sponsoring Maintainers
+
+A community member may also be accepted as nominee if sponsored by a commitee of 
+maintainers. Please refer to [GOVERNANCE.md](GOVERNANCE.md) for details about
+the nomination by commitee process.
+
+- @maintainer1
+- @maintainer2
+- @maintainer3
+
+## 💬 Discussion Start Date:
+
+A decision on the nomination shall be discussed for no longer than 30 days after
+the discussion start date. After the the discussion period is over, the vote
+tally will be computed and the nomination will be accepted or rejected. 
+
+**Start Date: 202Y-MM-DD**
+
+## 🗳️ Voting Results
+
+Final Enhancement Vote Tally:
+
+👍 : X Votes
+
+👎 : X Votes
+
+**Result:** __`APPROVED`__ | __`REJECTED`__
+
+
+## ℹ️ Voting Instructions: 
+
+To vote for this nomination, maintainers should add a comment with a 👍 emoji
+to show support or 👎 to reject the enhancement.  After voting is over (usually 
+after 30 days), votes will be computed by the project's mantainers and
+registered in this issue. Refer to  [GOVERNANCE.md](GOVERNANCE.md) for details
+on how many votes are required to approve and when voting ends.
+

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,64 @@
+## OpenVEX Community Code of Conduct
+
+### Contributor Code of Conduct
+
+As contributors and maintainers in the OpenVEX community, and in the interest
+of fostering an open and welcoming community, we pledge to respect all people
+who contribute through reporting issues, posting feature requests, updating
+documentation, submitting pull requests or patches, and other activities.
+
+We are committed to making participation in the OpenVEX community a 
+harassment-free experience for everyone, regardless of level of experience,
+gender, gender identity and expression, sexual orientation, disability, personal
+appearance, body size, race, ethnicity, age, religion, or nationality.
+
+## Scope 
+
+This code of conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+Project maintainers have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct. 
+
+By adopting this Code of Conduct, project maintainers commit themselves to
+fairly and consistently applying these principles to every aspect of managing
+this project. 
+
+Project maintainers who do not follow or enforce the Code of
+Conduct may be permanently removed from the project team.
+
+## Reporting 
+
+For incidents occurring in the Kubernetes community, contact the 
+[OpenVEX Maintainers](https://github.com/opevex/community/). 
+
+## Acknowledgements
+
+This Code of Conduct is adapted from the
+[Cloud Native Foundation's Code of Conduct](https://github.com/cncf/foundation/blob/fff715fb000ba4d7422684eca1d50d80676be254/code-of-conduct.md), itself derived from
+the Contributor Covenant (http://contributor-covenant.org), version 2.0 available at
+http://contributor-covenant.org/version/2/0/code_of_conduct/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
-# community
-OpenVEX project community documentation     
+# OpenVEX Community Repository
+
+The OpenVEX project aims to be inclusive community of enthusastic individuals
+interested in the exchange of vulnerability explitability data. 
+
+## Governance
+
+The Project aims to have a lean governance model that encourages quick decision
+making through a quick process of consensus building among its maintainers that
+captures opinions all interested parties. For more details please refer to the
+[GOVERNANCE](GOVERNANCE.md) document for more info on how we operate.
+
+## Code of Conduct
+
+All interactions between community members related to the project, both in
+public and private spaces are governed by our [Code of Conduct](CODE_OF_CONDUCT.md)
+
+## Contributing to the Project
+
+We are in the process of drafting our contributor's guide. If in doubt, please
+contact us directly.
+


### PR DESCRIPTION
This PR adds a number of documents to improve the community repo:

- Adds issue template for enhancement proposals 
- Adds issue template for maintainer nomination
- Code of condict
- Improves the readme a little bit more to have a landing page

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>
