### PR TITLE
Update community contact name from Kubernetes to OpenVEX

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -53,7 +53,7 @@ Conduct may be permanently removed from the project team.
 
 ## Reporting 
 
-For incidents occurring in the Kubernetes community, contact the 
+For incidents occurring in the OpenVEX community, contact the 
 [OpenVEX Maintainers](https://github.com/opevex/community/). 
 
 ## Acknowledgements


### PR DESCRIPTION
This appears to be a typo left from copying a CNCF CoC policy. I recommend clarifying this is to contact the OpenVEX maintainers and not the Kubernetes maintainers.